### PR TITLE
Use the correct snake growth mechanic when looking ahead

### DIFF
--- a/util.lua
+++ b/util.lua
@@ -74,13 +74,20 @@ function util.buildWorldMap( gameState )
     -- Place living snakes
     for i = 1, #gameState[ 'snakes' ][ 'data' ] do
         if gameState[ 'snakes' ][ 'data' ][i][ 'health' ] > 0 then
-            for j = 1, #gameState[ 'snakes' ][ 'data' ][i][ 'body' ][ 'data' ] do
+            local length = #gameState[ 'snakes' ][ 'data' ][i][ 'body' ][ 'data' ]
+            for j = 1, length do
                 local snake = gameState[ 'snakes' ][ 'data' ][i][ 'body' ][ 'data' ][j]
                 if j == 1 then
                     grid[ snake[ 'y' ] ][ snake[ 'x' ] ] = '@'
                     log( DEBUG, string.format( 'Placed snake head at [%s, %s]', snake[ 'x' ], snake[ 'y' ] ) )
+                elseif j == length then
+                    if grid[ snake[ 'y' ] ][ snake[ 'x' ] ] ~= '@' and grid[ snake[ 'y' ] ][ snake[ 'x' ] ] ~= '#' then
+                        grid[ snake[ 'y' ] ][ snake[ 'x' ] ] = '*'
+                    end
                 else
-                    grid[ snake[ 'y' ] ][ snake[ 'x' ] ] = '#'
+                    if grid[ snake[ 'y' ] ][ snake[ 'x' ] ] ~= '@' then
+                        grid[ snake[ 'y' ] ][ snake[ 'x' ] ] = '#'
+                    end
                     log( DEBUG, string.format( 'Placed snake tail at [%s, %s]', snake[ 'x' ], snake[ 'y' ] ) )
                 end
             end


### PR DESCRIPTION
The previous version of Robosnake has a couple bugs related to tracking the position of snake tails:

1) I assumed that when a piece of food has been eaten, the snake would grow on the same turn, and the existing tail wouldn't be removed. In actuality, it grows on the _next_ turn - after the snake has moved (without growing), the game board will duplicate the current position of its' tail. This means that when a snake eats, its' position would be off-by-one on the next turn (but corrected the turn after).

2) As long as a snake hasn't eaten in the current turn, the current position of its' tail should be considered a safe square to move to (because it will move out of that square as you move in). Previously we would always treat it as unsafe, which gave an advantage to enemy snakes that chased their tails, as we would assume they were trapped. 