### PR TITLE
Make failsafe prefer snake deaths over wall deaths if a death is inevitable.

### DIFF
--- a/algorithm.lua
+++ b/algorithm.lua
@@ -37,6 +37,7 @@ end
 
 --- Returns true if a square is safe to pass over, false otherwise
 -- @param v The value of a particular tile on the grid
+-- @param boolean failsafe If true, don't consider if the neighbour is safe or not
 -- @return boolean
 local function isSafeSquare( v, failsafe )
     if failsafe then
@@ -225,6 +226,8 @@ end
 
 --- Returns the set of all coordinate pairs on the board that are adjacent to the given position
 -- @param table pos The source coordinate pair
+-- @param table grid The game grid
+-- @param boolean failsafe If true, don't consider if the neighbour is safe or not
 -- @return table The neighbours of the source coordinate pair
 function algorithm.neighbours( pos, grid, failsafe )
     local neighbours = {}

--- a/robosnake.lua
+++ b/robosnake.lua
@@ -138,7 +138,7 @@ if not bestMove then
         -- This just prefers snake deaths over wall deaths, so that the official battlesnake
         -- unit tests pass.
         log( DEBUG, "FATAL: No free neighbours. I'm going to die. Trying to avoid a wall..." )
-        local my_moves = neighbours( myState[ 'me' ][ 'body' ][ 'data' ][1], grid, true )
+        my_moves = neighbours( myState[ 'me' ][ 'body' ][ 'data' ][1], grid, true )
         bestMove = my_moves[ math.random( #my_moves ) ]
     end
 end


### PR DESCRIPTION
If we're in a situation where we're going to die, but we have the choice of dying at the hands of another snake, or dying by crashing into a wall, pick the snake instead of picking at random.

This makes the official game board's tests pass when run against Robosnake.

Also I improved the logging and comments around the failsafe mechanism a bit.

Fixes #5 