### PR TITLE
Couple tricks for defending against aggressive snakes

### DIFF
--- a/algorithm.lua
+++ b/algorithm.lua
@@ -171,13 +171,10 @@ local function heuristic( grid, state, my_moves, enemy_moves )
         end
     end
     
-    local center_x = math.ceil( #grid[1] / 2 )
-    local center_y = math.ceil( #grid / 2 )
-    
     -- If there's food on the board, and I'm hungry, go for it
     -- If I'm not hungry, ignore it
     local foodWeight = 0
-    if state[ 'me' ][ 'health' ] <= HUNGER_HEALTH then
+    if state[ 'me' ][ 'health' ] <= HUNGER_HEALTH or #state[ 'me' ][ 'body' ][ 'data' ] < 4 then
         foodWeight = 100 - state[ 'me' ][ 'health' ]
     end
     log( DEBUG, 'Food Weight: ' .. foodWeight )
@@ -187,21 +184,40 @@ local function heuristic( grid, state, my_moves, enemy_moves )
             -- "i" is used in the score so that two pieces of food that 
             -- are equal distance from me do not have identical weighting
             score = score - ( dist * foodWeight ) - i
-            log( DEBUG, string.format('Food %s, distance %s, score %s', inspect( food[i] ), dist, ( dist * foodWeight ) - i ) )
+            log( DEBUG, string.format( 'Food %s, distance %s, score %s', inspect( food[i] ), dist, ( dist * foodWeight ) - i ) )
         end
     end
 
     -- Hang out near the enemy's head
     local kill_squares = algorithm.neighbours( state[ 'enemy' ][ 'body' ][ 'data' ][1], grid )
+    local enemy_last_direction = util.direction( state[ 'enemy' ][ 'body' ][ 'data' ][2], state[ 'enemy' ][ 'body' ][ 'data' ][1] )
     for i = 1, #kill_squares do
         local dist = mdist( state[ 'me' ][ 'body' ][ 'data' ][1], kill_squares[i] )
-        score = score - (dist * 100)
-        log( DEBUG, string.format('Kill square distance %s, score %s', dist, dist*100 ) )
+        local direction = util.direction( state[ 'enemy' ][ 'body' ][ 'data' ][1], kill_squares[i] )
+        if direction == enemy_last_direction then
+            score = score - ( dist * 200 )
+            log( DEBUG, string.format( 'Prime head target %s, distance %s, score %s', inspect( kill_squares[i] ), dist, dist * 200 ) )
+        else
+            score = score - ( dist * 100 )
+            log( DEBUG, string.format( 'Head target %s, distance %s, score %s', inspect( kill_squares[i] ), dist, dist * 100 ) )
+        end
+    end
+    
+    -- Avoid the edge of the game board
+    if
+        state[ 'me' ][ 'body' ][ 'data' ][1][ 'x' ] == 1
+        or state[ 'me' ][ 'body' ][ 'data' ][1][ 'x' ] == #grid[1]
+        or state[ 'me' ][ 'body' ][ 'data' ][1][ 'y' ] == 1
+        or state[ 'me' ][ 'body' ][ 'data' ][1][ 'y' ] == #grid
+    then
+        score = score - 25000
     end
      
     -- Hang out near the center
     -- Temporarily Disabled
-    --[[local dist = mdist( state[ 'me' ][ 'body' ][ 'data' ][1], { x = center_x, y = center_y } )
+    --[[local center_x = math.ceil( #grid[1] / 2 )
+    local center_y = math.ceil( #grid / 2 )
+    local dist = mdist( state[ 'me' ][ 'body' ][ 'data' ][1], { x = center_x, y = center_y } )
     score = score - (dist * 100)
     log( DEBUG, string.format('Center distance %s, score %s', dist, dist*100 ) )]]
     


### PR DESCRIPTION
 - If we're smaller than the default starting length (3) then prioritize food over aggression (if food is closer than enemy and depending on our health). This helps us against snakes that prioritize aggression over food in the early game, because we can headshot them.

 - Look at the enemy's current direction and use that to predict (weight) the square we think they'll move to next _slightly_ higher than the other squares around their head. This makes us attack them diagonally (if we're larger), pushing them towards an obstacle rather than dragging ourselves alongside them and hoping to hit an obstacle that way.

 - Weight the outer edge of the gameboard very unfavourably (but not so much that it interferes with win/loss or trap conditions). This is a defence mechanism against enemy snakes that try to pin us up against the wall (before minimax is able to predict our death).