### PR TITLE
Stop starving when playing under low food conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ Configuration is done in `/config/http.conf`.
 
 * `MAX_RECURSION_DEPTH` - this affects how far the alpha-beta pruning algorithm will look ahead. Increasing this will make SoR much smarter, but response times will be much longer.
 * `HUNGER_HEALTH` - when SoR's health dips to this value (or below) it will start looking for food.
+* `LOW_FOOD` - if the food on the game board is at this number or lower, SoR will use a less aggressive heuristic and prioritize food.

--- a/algorithm.lua
+++ b/algorithm.lua
@@ -182,8 +182,12 @@ local function heuristic( grid, state, my_moves, enemy_moves )
     -- If there's food on the board, and I'm hungry, go for it
     -- If I'm not hungry, ignore it
     local foodWeight = 0
-    if state[ 'me' ][ 'health' ] <= HUNGER_HEALTH or #state[ 'me' ][ 'body' ][ 'data' ] < 4 then
-        foodWeight = 100 - state[ 'me' ][ 'health' ]
+    if #food <= LOW_FOOD then
+        foodWeight = 200 - ( 2 * state[ 'me' ][ 'health' ] )
+    else
+        if state[ 'me' ][ 'health' ] <= HUNGER_HEALTH or #state[ 'me' ][ 'body' ][ 'data' ] < 4 then
+            foodWeight = 100 - state[ 'me' ][ 'health' ]
+        end
     end
     log( DEBUG, 'Food Weight: ' .. foodWeight )
     if foodWeight > 0 then
@@ -197,17 +201,21 @@ local function heuristic( grid, state, my_moves, enemy_moves )
     end
 
     -- Hang out near the enemy's head
+    local aggressiveWeight = 100
+    if #food <= LOW_FOOD then
+        aggressiveWeight = state[ 'me' ][ 'health' ]
+    end
     local kill_squares = algorithm.neighbours( state[ 'enemy' ][ 'body' ][ 'data' ][1], grid )
     local enemy_last_direction = util.direction( state[ 'enemy' ][ 'body' ][ 'data' ][2], state[ 'enemy' ][ 'body' ][ 'data' ][1] )
     for i = 1, #kill_squares do
         local dist = mdist( state[ 'me' ][ 'body' ][ 'data' ][1], kill_squares[i] )
         local direction = util.direction( state[ 'enemy' ][ 'body' ][ 'data' ][1], kill_squares[i] )
         if direction == enemy_last_direction then
-            score = score - ( dist * 200 )
-            log( DEBUG, string.format( 'Prime head target [%s,%s], distance %s, score %s', kill_squares[i][ 'x' ], kill_squares[i][ 'y' ], dist, dist * 200 ) )
+            score = score - ( dist * ( 2 * aggressiveWeight ) )
+            log( DEBUG, string.format( 'Prime head target [%s,%s], distance %s, score %s', kill_squares[i][ 'x' ], kill_squares[i][ 'y' ], dist, dist * ( 2 * aggressiveWeight ) ) )
         else
-            score = score - ( dist * 100 )
-            log( DEBUG, string.format( 'Head target [%s,%s], distance %s, score %s', kill_squares[i][ 'x' ], kill_squares[i][ 'y' ], dist, dist * 100 ) )
+            score = score - ( dist * aggressiveWeight )
+            log( DEBUG, string.format( 'Head target [%s,%s], distance %s, score %s', kill_squares[i][ 'x' ], kill_squares[i][ 'y' ], dist, dist * aggressiveWeight ) )
         end
     end
     

--- a/config/http.conf
+++ b/config/http.conf
@@ -6,6 +6,7 @@ init_by_lua_block {
     -- Constants
     MAX_RECURSION_DEPTH = 6
     HUNGER_HEALTH = 40
+    LOW_FOOD = 8
 
     -- Application Modules
     util = require( "util" )


### PR DESCRIPTION
This is experimental... keep our existing behavior when playing bounty games (10 food).

When playing under low food conditions (<= 8, but can be tweaked), use our health level as the balance between the aggressive heuristic and the food heuristic. Also increase the default weight of food to be closer to that of enemy heads.

Basically, this is to stop us from dying when playing on a board with 4 food. Shreyas told me at lunch today that the only way he could beat our snake was to play with 4 food and it got into my head a bit and long story short now he won't be able to beat us at all :)