### PR TITLE
Experimental support for head-on-neck collisions.

### DIFF
--- a/config/http.conf
+++ b/config/http.conf
@@ -7,6 +7,7 @@ init_by_lua_block {
     MAX_RECURSION_DEPTH = 6
     HUNGER_HEALTH = 40
     LOW_FOOD = 8
+    HEAD_ON_NECK_DETECTION = true
 
     -- Application Modules
     util = require( "util" )


### PR DESCRIPTION
If Stephen's PR to the official game board gets merged, then we have to deal with the case of head-on-neck collisions being treated identically to that of head-on-head collisions.

This is a pretty invasive change to our core play-ahead logic so it's feature-flagged via a new toggle in http.conf.

Basically...
 - Enemy snake heads are now considered fair game to move into. Because all snakes execute moves simultaneously, attempting to move into an enemy snake's head will actually place us in their neck (the second segment of their json).
 - If we're in their neck and they're in our neck, treat it in the same way as a head-on-head collision (larger snake wins, both die if equal).
 - Collisions can only be evaluated on even-numbered recursion depths (because all snakes execute moves simultaneously)... the problem is that a head-on-neck collision that we start at one depth of minimax could be seen as a head-on-head from the next depth.
 - We now also have to consider the case where we attempt a head-on-neck attack, but the enemy moves out of the way and our head is now inside their body - this is a side effect of making enemy heads fair game to move into - so the heuristic and leaf node detection must compare our head to the enemy body segments (and vice versa).

I tested this using some handcrafted JSON, and on the official game board (obviously since Stephen's PR isn't merged right now, both snakes always die in a successful head-on-neck attack but you can see that the attempt took place). I didn't observe any regressions (and I ran Devin's unit tests) but with a change as invasive as this it's hard to say that I'm completely confident.

My recommendation here is that we merge, but leave disabled in http.conf unless Stephen's PR gets merged, and only then do we enable it.